### PR TITLE
Install jq in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,9 @@ jobs:
             - "df:28:22:a5:34:e9:ff:87:b4:15:05:d2:72:57:99:70"
       - run:
           name: Update data sets.
-          command: bash -x .circleci/update-datasets.sh
+          command: |
+            apk add --update --no-cache jq
+            bash -x .circleci/update-datasets.sh
 
 workflows:
   version: 2


### PR DESCRIPTION
Adds the installation of the `jq` package in the CircleCI container.

Fixes scrapd/datasets#10