### PR TITLE
Fix package install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,8 @@ jobs:
       - run:
           name: Update data sets.
           command: |
-            apk add --update --no-cache jq
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends jq
             bash -x .circleci/update-datasets.sh
 
 workflows:
@@ -48,7 +49,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 3 * * *"
+          cron: "0 9 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
The base image is a Debian image, not Alpine, therefore the packages
must be installed with apt-get.

Drive-by:
* The time zone in the container is UTC, so the cron trigger was
  adjusted accordingly.