### PR TITLE
Use pycalver for tagging

### DIFF
--- a/.circleci/update-datasets.sh
+++ b/.circleci/update-datasets.sh
@@ -22,7 +22,9 @@ if [ -n "${HAS_CHANGE}" ]; then
   git commit -am "Update data sets" \
     -m "There are ${NEW_ENTRY_COUNT} new entries in the current data set." \
     -m "${HAS_CHANGE}"
+  pycalver bump --patch
   git push origin master
+  git push --tags
 else
   echo "There is nothing new to commit."
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pycalver==201902.27
+pycalver==201903.28
 scrapd==1.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pycalver]
-current_version = "19.03.1.0"
+current_version = "19.03.01.0"
 version_pattern = "{yy}.{month}.{dom}.{PATCH}"
 commit = True
 tag = True


### PR DESCRIPTION
Adds pycalver commands to the update script to be able to automatically
tag the repository when new data is added.

Fixes scrapd/datasets#9