### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ working_directory: &working_directory
 
 defaults: &defaults
   docker:
-    - image: circleci/python:3.7.2-stretch-node
+    - image: circleci/python:3.7-buster
   working_directory: *working_directory
   environment:
       TZ: "America/Chicago"


### PR DESCRIPTION
Pin docker image to `python:3.7-buster` to avoid this job to fail during minor version upgrades.